### PR TITLE
Fix star-related mutations

### DIFF
--- a/src/RepositoryStar.js
+++ b/src/RepositoryStar.js
@@ -12,8 +12,8 @@ function starMutation(starrableId) {
   commitMutation(environment, {
     variables,
     mutation: graphql`
-      mutation RepositoryStarStarMutation($input: StarInput!) {
-        star(input: $input) {
+      mutation RepositoryStarStarMutation($input: AddStarInput!) {
+        addStar(input: $input) {
           starrable {
             ...RepositoryStar_repository
           }
@@ -33,8 +33,8 @@ function unstarMutation(starrableId) {
   commitMutation(environment, {
     variables,
     mutation: graphql`
-      mutation RepositoryStarUnstarMutation($input: UnstarInput!) {
-        unstar(input: $input) {
+      mutation RepositoryStarUnstarMutation($input: RemoveStarInput!) {
+        removeStar(input: $input) {
           starrable {
             ...RepositoryStar_repository
           }


### PR DESCRIPTION
## Description

When I tried to run this locally I got some errors around starring mutations. This PR tweaks those mutations to work with the current [removeStar](https://developer.github.com/v4/reference/mutation/removestar/) and [addStar](https://developer.github.com/v4/reference/mutation/addstar/) mutation APIs.

## Test plan

1. Run `yarn start`
1. Verify the app successfully starts instead of outputting the error below
1. Verify navigating to [http://localhost:3000](http://localhost:3000) shows the app and staring/unstarring repos works

## Full error output

<details>
  <summary>Expand full error output</summary>

```
➜  gh-dash git:(master) yarn start
yarn start v0.24.5
$ yarn setup && node scripts/start.js
yarn setup v0.24.5
$ yarn install && yarn run get-token && yarn run get-schema && yarn run relay
yarn install v0.24.5
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.53s.
yarn run v0.24.5
$ node scripts/getToken.js
✨  Done in 0.33s.
yarn run v0.24.5
$ node scripts/getSchema.js
✨  Done in 3.56s.
yarn run v0.24.5
$ relay-compiler --src ./src --schema schema.graphql
HINT: pass --watch to keep watching for changes.
Parsed default in 0.13s

Writing default
Error: You supplied a GraphQL document with validation errors:


Unknown type "UnstarInput". Did you mean "AddStarInput" or "RemoveStarInput"?
Unknown type "StarInput". Did you mean "AddStarInput" or "RemoveStarInput"?
    at Object.validateOrThrow [as validate] (/Users/thomas/code/gh-dash/node_modules/relay-compiler/bin/relay-compiler:3769:18)
    at convertASTDefinitions (/Users/thomas/code/gh-dash/node_modules/relay-compiler/bin/relay-compiler:1140:28)
    at Object.convertASTDocumentsWithBase (/Users/thomas/code/gh-dash/node_modules/relay-compiler/bin/relay-compiler:1122:11)
    at RelayFileWriter.<anonymous> (/Users/thomas/code/gh-dash/node_modules/relay-compiler/bin/relay-compiler:5738:50)
    at next (native)
    at step (/Users/thomas/code/gh-dash/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/thomas/code/gh-dash/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
    at new Promise (/Users/thomas/code/gh-dash/node_modules/core-js/library/modules/es6.promise.js:191:7)
    at RelayFileWriter.<anonymous> (/Users/thomas/code/gh-dash/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12)
    at RelayFileWriter.writeAll (/Users/thomas/code/gh-dash/node_modules/relay-compiler/bin/relay-compiler:5829:20)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
error Command failed with exit code 1.
```

</details>