### PR TITLE
Update the README to include Watchman install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Demonstrates how to use [Relay Modern](https://facebook.github.io/relay/docs/rel
 
 ### Running locally
 
-First, you'll need a GitHub API access token to make GraphQL API requests. You can get that [here](https://github.com/settings/tokens/new).
+This repo relies on FB's [Watchman](https://facebook.github.io/watchman) service. Follow the [instructions here](https://facebook.github.io/watchman/docs/install.html#buildinstall) for installing it globally.
+
+You'll need a GitHub API access token to make GraphQL API requests. You can get that [here](https://github.com/settings/tokens/new).
 
 ```
 $ git clone https://github.com/github/github-graphql-relay-example


### PR DESCRIPTION
## Description

I was briefly confused when I first tried to run this when I got an error on `yarn start` telling me I needed to install Watchman globally for stuff to work. This PR adds a brief blurb to the README in the "Running locally" section explicitly calling out the installation step and providing a link to instructions.

## Full error output

<details>
  <summary>See full error log here</summary>

```
➜  gh-dash git:(watchman-readme) yarn start
yarn start v0.24.5
$ yarn setup && node scripts/start.js
yarn setup v0.24.5
$ yarn install && yarn run get-token && yarn run get-schema && yarn run relay
yarn install v0.24.5
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.48s.
yarn run v0.24.5
$ node scripts/getToken.js
✨  Done in 0.18s.
yarn run v0.24.5
$ node scripts/getSchema.js
✨  Done in 4.25s.
yarn run v0.24.5
$ relay-compiler --src ./src --schema schema.graphql
HINT: pass --watch to keep watching for changes.
Watchman:  Watchman was not found in PATH.  See https://facebook.github.io/watchman/docs/install.html for installation instructions
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: Watchman was not found in PATH.  See https://facebook.github.io/watchman/docs/install.html for installation instructions
    at exports._errnoException (util.js:1007:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:182:32)
    at onErrorNT (internal/child_process.js:348:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Module.runMain (module.js:577:11)
    at run (node.js:348:7)
    at startup (node.js:140:9)
    at node.js:463:3
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
error Command failed with exit code 1.
```

</details>